### PR TITLE
Update start matches week two for drops/adds

### DIFF
--- a/Strings.js
+++ b/Strings.js
@@ -27,6 +27,7 @@ module.exports = {
             MATCHES_THREAD_TITLE: (title, week) => `${title} week ${week} matches`,
             DECKLIST_THREAD_TITLE: (title, week) => `${title} week ${week} decklists`,
             PAIRING_MESSAGE: (user1, user2) => `${user1} vs ${user2}`,
+            DROPS_MESSAGE: (drop, add) => `React with ${drop} if you want to drop for week 2 or with ${add} if you want to join (no buy-in).`,
         },
         LITERALS: {
             FOLLOWUP_THREAD_INFO: 'I will post two follow-up threads: one for match pairings and one for decklists. \n',
@@ -38,6 +39,8 @@ module.exports = {
             ONE_EMOJI: '1️⃣',
             ZERO_EMOJI: '0️⃣',
             TIE_EMOJI: '👔',
+            DROP_EMOJI: '💧',
+            ADD_EMOJI: '➕',
         },
     },
 }

--- a/commands/startBrew.js
+++ b/commands/startBrew.js
@@ -57,6 +57,7 @@ module.exports = {
             let lineFour = Strings.BREW_WEEK.TEMPLATES.SCRYFALL_LINE(scryFallString)
             let lineFive = Strings.TEMPLATES.SIGN_UP_REACTIONS(Strings.PAY_IN_EMOJI, Strings.F2P_EMOJI)
             const message = await interaction.reply({ content: tagLine + lineOne + lineTwo + lineThree + lineFour + lineFive, fetchReply: true })
+            await message.pin()
             message.react(Strings.PAY_IN_EMOJI)
             message.react(Strings.F2P_EMOJI)
         },

--- a/messageFiltering.js
+++ b/messageFiltering.js
@@ -1,0 +1,48 @@
+const { clientId } = require('./config.json');
+const { matchFormatString, FORMAT_PLACEHOLDER } = require('./stringParsing')
+const Strings = require('./Strings')
+
+module.exports = {
+    async getBotMessages(interaction) {
+        let botMessages
+        await interaction.channel.messages.fetch({ limit: 100 })
+                .then(messages => {
+                    botMessages = Array.from(messages.filter(m => m.author.id === clientId).values())
+                }
+                )
+        return botMessages
+    },
+    getStandardTitle(botMessages) {
+        // To-do: Handle failure of no previous standard title
+        let standardTitle
+        botMessages.find(message => {
+            standardTitle = matchFormatString(message.content, Strings.BREW_WEEK.TEMPLATES.TITLE_LINE(FORMAT_PLACEHOLDER))
+            if (standardTitle.length > 0) {
+                return true
+            }
+            return false
+        })
+        return standardTitle
+    },
+    async getReactions(botMessages, formatString) {
+        let reactionEmojis
+        let reactionMap = []
+        let reactions
+
+        let reactionMessage = botMessages.find(message => {
+            reactionEmojis = matchFormatString(message.content, formatString)
+            return (reactionEmojis.length > 0)
+        })
+        if (reactionMessage != undefined) {
+            reactions = reactionMessage.reactions.cache
+        }
+        for (const reactionEmoji of reactionEmojis) {
+            await reactions.get(reactionEmoji).users.fetch()
+            .then(users => {
+                let filteredUsers = Array.from(users.values()).filter(user => user.id !== clientId)
+                reactionMap.push([reactionEmoji, filteredUsers])
+            })
+        }
+        return reactionMap
+    },
+}

--- a/stringParsing.js
+++ b/stringParsing.js
@@ -1,11 +1,17 @@
 module.exports = {
     FORMAT_PLACEHOLDER: '$/$',
     matchFormatString(toMatch, templateString) {
-        let split = templateString.replace(/\n$/g, '').split('$/$')
+        let splitString = templateString.replace(/\n$/g, '').split('$/$')
         let matches = []
-        for (let i = 0; i < split.length - 1; i++) {
-            let split1 = split[i]
-            matches.push(toMatch.substring(toMatch.indexOf(split1) + split1.length, toMatch.indexOf(split[i + 1])))
+        for (let i = 0; i < splitString.length - 1; i++) {
+            let segment = splitString[i]
+            let firstFind = toMatch.indexOf(segment)
+            if (firstFind > 0) {
+                let match = toMatch.substring(toMatch.indexOf(segment) + segment.length, toMatch.indexOf(splitString[i + 1]))
+                if (match) {
+                    matches.push(match)
+                }
+            }
         }
         return matches
     },


### PR DESCRIPTION
Updated the start matches command for week two. We decided we don't want to have to re-do signups week two, so instead I have it so that there is a `drop` or `add` ability.

Additionally, I moved some code out from just the huge main functions into smaller, more readable functions (as well as the functions in `messageFiltering.js` that will be used across multiple commands)